### PR TITLE
conditional-jar-downloads: avoid downloading files, if their remote content hasn't changed since the last download

### DIFF
--- a/standAlone/wss_agent.sh
+++ b/standAlone/wss_agent.sh
@@ -1,7 +1,7 @@
-#!/bin/bash 
+#!/bin/bash
 
-curl -LJO https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar
+curl -LJO https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar -z wss-unified-agent.jar
 
-curl -LJO https://github.com/whitesource/unified-agent-distribution/raw/master/standAlone/wss-unified-agent.config
+curl -LJO https://github.com/whitesource/unified-agent-distribution/raw/master/standAlone/wss-unified-agent.config -z wss-unified-agent.config
 
 java -jar wss-unified-agent.jar "$@"


### PR DESCRIPTION
This PR tries to avoid constant re-downloading of the files wss-unified-agent.jar and wss-unified-agent.config, if the local last-modified-date is equal or newer than the last-modified-date of the remote file. This concept is known as [Conditional GET Request](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.3) and is commonly used to save download times and reduce unnecessary network usage. curl's -z option takes care of the heavy work here, see `man curl`.